### PR TITLE
Disable Next.js Default Body Parser

### DIFF
--- a/pages/api/demo/[...apiGateway].ts
+++ b/pages/api/demo/[...apiGateway].ts
@@ -34,5 +34,6 @@ export default apiGateway;
 export const config = {
     api: {
         externalResolver: true,
+        bodyParser: false
     },
 }


### PR DESCRIPTION
This PR will disable the Next.js default `bodyParser` config on demo API Gateway example. This is needed since the API Gateway couldn't properly send HTTP request with body to the back-end server.